### PR TITLE
Update dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,2 @@
-{
-  "env": {
-    "node": true,
-  },
-  "extends": [
-    "metalab/rules/babel",
-    "metalab/rules/best-practices",
-    "metalab/rules/docs",
-    "metalab/rules/errors",
-    "metalab/rules/filenames",
-    "metalab/rules/modern",
-    "metalab/rules/react",
-    "metalab/rules/style"
-  ]
-}
+extends:
+  - metalab

--- a/package.json
+++ b/package.json
@@ -12,27 +12,27 @@
     "test": "./node_modules/.bin/mocha dist/test/spec/"
   },
   "devDependencies": {
-    "babel-cli": "^6.0.14",
-    "babel-eslint": "^4.1.3",
+    "babel-cli": "^6.1.1",
+    "babel-eslint": "^4.1.4",
     "babel-preset-metalab": "^0.1.0",
     "chai": "^3.4.0",
     "eslint": "^1.6.0",
-    "eslint-config-metalab": "^0.2.2",
+    "eslint-config-metalab": "^0.4.0",
     "eslint-plugin-filenames": "^0.1.2",
     "eslint-plugin-import": "^0.8.1",
     "eslint-plugin-react": "^3.6.3",
     "jsdom": "^7.0.2",
     "mocha": "^2.3.3",
-    "react": "^0.14.1",
-    "react-addons-test-utils": "^0.14.1",
-    "react-dom": "^0.14.1",
+    "react": "^0.14.2",
+    "react-addons-test-utils": "^0.14.2",
+    "react-dom": "^0.14.2",
     "redux": "^3.0.4"
   },
   "dependencies": {
     "lodash.omit": "^3.1.0",
     "multi-provider": "^0.1.1",
     "react-redux": "^4.0.0",
-    "redux-lift": "^0.1.1",
+    "redux-lift": "^0.1.3",
     "wrap-component": "^0.1.0"
   }
 }

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -1,4 +1,4 @@
-import React, { Component, createElement } from 'react';
+import { Component, createElement } from 'react';
 import { connect } from 'react-redux';
 import storeShape from 'react-redux/lib/utils/storeShape';
 import wrapComponent from 'wrap-component';

--- a/test/fixtures/basic-component.js
+++ b/test/fixtures/basic-component.js
@@ -1,0 +1,7 @@
+import { Component, createElement } from 'react';
+
+export default class BasicComponent extends Component {
+  render() {
+    return <span>cheezy potatos</span>;
+  }
+}

--- a/test/fixtures/dom.js
+++ b/test/fixtures/dom.js
@@ -1,0 +1,13 @@
+import jsdom from 'jsdom';
+
+// Setup the simplest document possible.
+const document = jsdom.jsdom('<!doctype html><html><body></body></html>');
+
+// Set the window object out of the document.
+const window = document.defaultView;
+
+export default {
+  document,
+  window,
+  ...window,
+};

--- a/test/fixtures/value-component.js
+++ b/test/fixtures/value-component.js
@@ -1,0 +1,13 @@
+import { Component, createElement, PropTypes } from 'react';
+
+export default class ValueComponent extends Component {
+  render() {
+    return <span>{this.props.state.value}</span>;
+  }
+}
+
+ValueComponent.propTypes = {
+  state: PropTypes.shape({
+    value: PropTypes.string.isRequired,
+  }),
+};


### PR DESCRIPTION
- Update `.eslintrc` to reference the modified presets in eslint-config-metalab.
- Take advantage of the change in babel-preset-metalab from nealgranger/babel-preset-metalab#1.
- Creating them as fixtures since multiple React classes can't be defined in a single file. 
